### PR TITLE
treat all arguments to concat functions consistently

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,8 @@
     "eqeqeq": [0],
     // make tab width > max len to disallow tab characters
     "max-len": [2, 79, 80],
+    "new-cap": [0],
+    "new-parens": [0],
     "no-new-func": [0],
     "no-new-wrappers": [0],
     "quotes": [2, "single", "avoid-escape"]

--- a/nucleotides.js
+++ b/nucleotides.js
@@ -74,7 +74,9 @@ void function() {
           // unsuffixed names for future use.
           return [
             isMutator(method) ? method.name + '!' : method.name,
-            _.bind(Function.prototype.call, method)
+            method.name === 'concat' ?
+              _.bind(method, new ctor) :
+              _.bind(Function.prototype.call, method)
           ];
         })
         .object()

--- a/test/nucleotides.js
+++ b/test/nucleotides.js
@@ -285,6 +285,15 @@ suite('nucleotides.array', function() {
     assert.deepEqual(nucleotides.array.filter([-1, 0, 1], Boolean), [-1, 1]);
   });
 
+  test('concat', function() {
+    assert.deepEqual(nucleotides.array.concat([1], [2], 3), [1, 2, 3]);
+    assert.deepEqual(nucleotides.array.concat([1], [2, [3]]), [1, 2, [3]]);
+    assert.deepEqual(nucleotides.array.concat(['foo'], null), ['foo', null]);
+    assert.deepEqual(nucleotides.array.concat(null, ['bar']), [null, 'bar']);
+    assert.deepEqual(nucleotides.array.concat('foo', 'bar'), ['foo', 'bar']);
+    assert.deepEqual(nucleotides.array.concat(), []);
+  });
+
 });
 
 
@@ -305,6 +314,20 @@ suite('nucleotides.date', function() {
     e = new Date(2010, 10, 13);
     assert.strictEqual(nucleotides.date['setDate!'](d, 13), e.valueOf());
     assert.strictEqual(d.valueOf(), e.valueOf());
+  });
+
+});
+
+
+suite('nucleotides.string', function() {
+
+  test('concat', function() {
+    assert.strictEqual(nucleotides.string.concat('foo', 'bar'), 'foobar');
+    assert.strictEqual(nucleotides.string.concat('foo', null), 'foonull');
+    assert.strictEqual(nucleotides.string.concat(null, 'bar'), 'nullbar');
+    assert.strictEqual(nucleotides.string.concat(1, 2, 3, 4, 5), '12345');
+    assert.strictEqual(nucleotides.string.concat([1, 2, 3], 4, 5), '1,2,345');
+    assert.strictEqual(nucleotides.string.concat(), '');
   });
 
 });


### PR DESCRIPTION
Currently the first argument must be of the appropriate type to avoid surprising results, but arguments beyond the first may be of any type.

/cc @buzzdecafe, @CrossEye, @megawac
